### PR TITLE
Add line to loadNpmTasks

### DIFF
--- a/Django/Django-livereload.md
+++ b/Django/Django-livereload.md
@@ -18,6 +18,9 @@ grunt.initConfig({
     }
     // ...
 });
+
+grunt.loadNpmTasks('grunt-contrib-watch'); 
+	
 grunt.registerTask('default', [
     // add all tasks you need including watch
     'watch' 


### PR DESCRIPTION
Calling loadNpmTasks is required to make the watch command work, so adding line to show that